### PR TITLE
Removing the local mvn repo.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN cd /opt &&\
   -Dmdep.stripClassifier=true
 
 RUN unzip -qq -d /opt /opt/hawkular-kettle.zip;\
-    rm /opt/hawkular-kettle.zip;\
+    rm -rf /opt/hawkular-kettle.zip /root/.m2;\
     /opt/wildfly-8.2.0.Final/bin/add-user.sh hawkularadmin hawkularadmin --silent
 
 EXPOSE 8080 9990


### PR DESCRIPTION
When running mvn command, it downloads all the universe, so let's delete it all and reduce the container size by up to 500 megs. Currently the it takes 1.8GB, this is too much.

(inside the container)
before:

``` bash
[root@c537eefc484d repository]# df -h
Filesystem                                                                                         Size  Used Avail Use% Mounted on
/dev/mapper/docker-253:1-2370230-c537eefc484d6725b45189e2797001d4bac50a76e3f3c6e3c34d3e17e9f65ffa  9.8G  1.4G  7.9G  15% /
tmpfs                                                                                              7.8G     0  7.8G   0% /dev
shm                                                                                                 64M     0   64M   0% /dev/shm
/dev/mapper/fedora-root                                                                             50G   26G   21G  56% /etc/hosts
tmpfs                                                                                              7.8G     0  7.8G   0% /proc/kcore
```

after:

``` bash
[root@c537eefc484d repository]# rm -Rf /root/.m2
[root@c537eefc484d repository]# df -h
Filesystem                                                                                         Size  Used Avail Use% Mounted on
/dev/mapper/docker-253:1-2370230-c537eefc484d6725b45189e2797001d4bac50a76e3f3c6e3c34d3e17e9f65ffa  9.8G  845M  8.4G   9% /
tmpfs                                                                                              7.8G     0  7.8G   0% /dev
shm                                                                                                 64M     0   64M   0% /dev/shm
/dev/mapper/fedora-root                                                                             50G   26G   21G  56% /etc/hosts
tmpfs                                                                                              7.8G     0  7.8G   0% /proc/kcore
```

Other ways to lower the size could be using some simpler base image like scratch, here is nice blog post about reducing the size http://jasonwilder.com/blog/2014/08/19/squashing-docker-images/. It's quite outdated so perhaps some form of squashing is already built in Docker.
