### PR TITLE
Issue #2: chaining the 'mvn ...' and 'rm -rf ~/.m2' together 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,8 @@ RUN cd /opt &&\
   -Dartifact="${ARTIFACT}"\
   -DoutputDirectory=.\
   -Dmdep.stripVersion=true\
-  -Dmdep.stripClassifier=true
-
-RUN unzip -qq -d /opt /opt/hawkular-kettle.zip;\
+  -Dmdep.stripClassifier=true &&\
+ unzip -qq -d /opt /opt/hawkular-kettle.zip;\
     rm -rf /opt/hawkular-kettle.zip /root/.m2;\
     /opt/wildfly-8.2.0.Final/bin/add-user.sh hawkularadmin hawkularadmin --silent
 


### PR DESCRIPTION
Not to increase the size of the container by introducing a new layer.

Resulting image should be 1.031 GB in size.
