### PR TITLE
Openshift seems to need group exec permission

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@
 : ${JBOSS_BASE:=/opt/jboss}
 . ${JBOSS_BASE}/build-env
 unzip -qq -d ${JBOSS_BASE} ${JBOSS_BASE}/hawkular-dist.zip &&\
+chmod ug+x ${JBOSS_BASE}/hawkular-live/bin/*.sh &&\
 ln -s ${JBOSS_BASE}/hawkular-${HAWKULAR_VERSION} ${JBOSS_BASE}/hawkular-live &&\
 rm -f ${JBOSS_BASE}/hawkular-dist.zip
 


### PR DESCRIPTION
unable to start hawkular in OSE3.1

```
[root@openshift-master1 ~]# docker logs -f fd7a27a89a22
 ## Setting Hawkular URL to localhost:8080 ##
/opt/jboss/hawkular-start.sh: line 47: /opt/jboss/hawkular-live/bin/standalone.sh: Permission denied
```

standalone.sh inside docker

```
-rwxr-xr--. 1 jboss jboss 13338 Jul 23 21:01 hawkular-live/bin/standalone.sh
```
